### PR TITLE
Add label filter navigation

### DIFF
--- a/app/[orgId]/tasks/page.tsx
+++ b/app/[orgId]/tasks/page.tsx
@@ -1,0 +1,12 @@
+import MainLayout from '@/components/layout/main-layout';
+import Header from '@/components/layout/headers/tasks/header';
+import AllTasks from '@/components/common/tasks/all-tasks';
+
+export default function TasksPage({ searchParams }: { searchParams?: { label?: string } }) {
+  const label = Array.isArray(searchParams?.label) ? searchParams?.label[0] : searchParams?.label;
+  return (
+    <MainLayout header={<Header />}>
+      <AllTasks initialLabel={label} />
+    </MainLayout>
+  );
+}

--- a/components/common/tasks/all-tasks.tsx
+++ b/components/common/tasks/all-tasks.tsx
@@ -5,7 +5,7 @@ import { useTasksStore } from '@/store/tasks-store';
 import { useSearchStore } from '@/store/search-store';
 import { useViewStore } from '@/store/view-store';
 import { useFilterStore } from '@/store/filter-store';
-import { FC, useMemo } from 'react';
+import { FC, useMemo, useEffect } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { GroupTasks } from './group-tasks';
@@ -14,10 +14,18 @@ import { CustomDragLayer } from './task-grid';
 import { cn } from '@/lib/utils';
 import { Task } from '@/mock-data/tasks';
 
-export default function AllTasks() {
+export default function AllTasks({ initialLabel }: { initialLabel?: string }) {
    const { isSearchOpen, searchQuery } = useSearchStore();
    const { viewType } = useViewStore();
-   const { hasActiveFilters } = useFilterStore();
+   const { hasActiveFilters, setFilter, clearFilterType } = useFilterStore();
+
+   useEffect(() => {
+      if (initialLabel) {
+         setFilter('labels', [initialLabel]);
+      } else {
+         clearFilterType('labels');
+      }
+   }, [initialLabel, setFilter, clearFilterType]);
 
    const isSearching = isSearchOpen && searchQuery.trim() !== '';
    const isViewTypeGrid = viewType === 'grid';

--- a/components/layout/sidebar/app-sidebar.tsx
+++ b/components/layout/sidebar/app-sidebar.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { HelpButton } from '@/components/layout/sidebar/help-button';
 import { NavInbox } from '@/components/layout/sidebar/nav-inbox';
 import { NavLabels } from '@/components/layout/sidebar/nav-labels';
-import { NavWorkspace } from '@/components/layout/sidebar/nav-workspace';
 import { NavAccount } from '@/components/layout/sidebar/nav-account';
 import { NavFeatures } from '@/components/layout/sidebar/nav-features';
 import { NavTeamsSettings } from '@/components/layout/sidebar/nav-teams-settings';

--- a/components/layout/sidebar/nav-labels.tsx
+++ b/components/layout/sidebar/nav-labels.tsx
@@ -1,36 +1,13 @@
 'use client';
 
-import {
-   Archive,
-   Bell,
-   Box,
-   ChevronRight,
-   CopyMinus,
-   Layers,
-   Link as LinkIcon,
-   MoreHorizontal,
-   Settings,
-} from 'lucide-react';
 import Link from 'next/link';
 
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import {
-   DropdownMenu,
-   DropdownMenuContent,
-   DropdownMenuItem,
-   DropdownMenuSeparator,
-   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import {
    SidebarGroup,
    SidebarGroupLabel,
    SidebarMenu,
-   SidebarMenuAction,
    SidebarMenuButton,
    SidebarMenuItem,
-   SidebarMenuSub,
-   SidebarMenuSubButton,
-   SidebarMenuSubItem,
 } from '@/components/ui/sidebar';
 import { labels } from '@/mock-data/labels';
 


### PR DESCRIPTION
## Summary
- add `/tasks` route under organization to list tasks
- support initial label filter via `initialLabel`
- remove unused imports in sidebar components

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'project' does not exist on type 'Task')*

------
https://chatgpt.com/codex/tasks/task_e_684c91db3f908330b6b92656cf87ade9